### PR TITLE
fix: update links

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 [//]: # ([![Track Awesome List]&#40;https://www.trackawesomelist.com/badge.svg&#41;]&#40;https://www.trackawesomelist.com/avelino/awesome-go/&#41;)
 
-Foundry is a blazing fast, portable and modular toolkit for Ethereum application development written in Rust. [Install Foundry here](https://github.com/gakonst/foundry).
+Foundry is a blazing fast, portable and modular toolkit for Ethereum application development written in Rust. [Install Foundry here](https://getfoundry.sh).
 
 <img align="center" src="https://mirror.xyz/_next/image?url=https%3A%2F%2Fimages.mirror-media.xyz%2Fpublication-images%2Fkt99mFtZZ1Gl2ZbWGNI3J.png&w=3840&q=90" alt="awesome-foundry" title="awesome-foundry" />
 
@@ -33,13 +33,12 @@ Please take a quick gander at the [contribution guidelines](https://github.com/c
 
 ## Tools
 Frameworks, plugins and utilities for Foundry.
-- [Foundryup](https://github.com/gakonst/foundry/tree/master/foundryup) - Update or revert to a specific Foundry branch with ease.
+- [Foundryup](https://github.com/foundry-rs/foundry/tree/master/foundryup) - Update or revert to a specific Foundry branch with ease.
 - [Foundry Template](https://github.com/ZeframLou/foundry-template) - A template for a Foundry project.
 - [Forge Template](https://github.com/FrankieIsLost/forge-template) - A template for quickly getting started with forge.
-- [Forge Standard Library](https://github.com/brockelmore/forge-std/) - Collection of helpful contracts for use with forge and foundry.
-- [Forge CI](https://gist.github.com/clifton/b5ee5286bb229281fb31d7c4b15e6f31) - Simple Github Actions workflow to run forge test.
+- [Forge Standard Library](https://github.com/foundry-rs/forge-std/) - Collection of helpful contracts for use with forge and foundry.
+- [Forge GHA](https://github.com/foundry-rs/foundry-toolchain) - Simple Github Actions workflow to run forge test.
 - [Forge Replit](https://replit.com/@wilsonc/VanillaForge) - Run Forge in the browser, vanilla setup.
-- [Gitpod Template](https://github.com/gakonst/forge-template/blob/master/.gitpod.yml) - Gitpod configuration file.
 - [Foundrydeploy](https://github.com/joshieDo/foundrydeploy) - Limited scripting (declarative?) language to implement a basic deployment pipeline using foundry. 
 
 ## Libraries
@@ -59,7 +58,7 @@ Solidity libraries or utilities that use Foundry.
 - [Getting Started by Wilson](https://w.mirror.xyz/mOUlpgkWA178HNUW7xR20TdbGRV6dMid7uChqxf9Z58) - Extended tutorial with information about testings and logging.
 - [Getting Started by What The Func?](https://youtu.be/wqFnif_6Mbc) - Video tutorial.
 - [How to Foundry with Brock Elmore](https://www.youtube.com/watch?v=Rp_V7bYiTCM) - YouTube live code tutorial on how to get started with Foundry.
-- [Foundry Book](https://onbjerg.github.io/foundry-book/) - A book on all things Foundry.
+- [Foundry Book](https://book.getfoundry.sh/) - A book on all things Foundry.
 - [Mainnet Forking](https://mirror.xyz/susheen.eth/bRCzT2QLdNINMVk8251udkfjHW_T9ascCQ1DV9hURz0) - This article teaches how to run a locally simulate a swap on Uniswap.
 - [Ethernaut x Foundry](https://github.com/ciaranmcveigh5/ethernaut-x-foundry) - Ethernaut puzzles solved & tested with foundry.
 - [Damn Vulnerable Defi - Foundry Version](https://github.com/nicolasgarcia214/damn-vulnerable-defi-foundry) - The Damn Vulnerable Defi CTF using Foundry.
@@ -69,6 +68,5 @@ Solidity libraries or utilities that use Foundry.
 - [MapleLoan](https://github.com/maple-labs/loan) - Set of contracts to facilitate on-chain Loans between Maple Finance Pools and institutional borrowers.
 - [Cryptex Finance](https://github.com/cryptexfinance/contracts) - Index token that tracks the total cryptocurrency market capitalization. (Optimism version uses Foundry tests).
 - [Gov of Venice](https://github.com/pentagonxyz/gov-of-venice) - Governance of Venice is a new paradigm in DAO governance, attempting to standardise the existence of functional groups within DAOs (Guilds) in terms of how they participate in the Governance process of different DAOs. 
-
 
 **[⬆ back to top](#awesome-foundry)**


### PR DESCRIPTION
Some of the repos moved to the new org and some of the links were moved onto getfoundry.sh (the book, installation etc.)